### PR TITLE
Add serialization_utils package

### DIFF
--- a/projects_machines_in_motion.yaml
+++ b/projects_machines_in_motion.yaml
@@ -56,7 +56,7 @@ COMPILATION:
     repos: ['mpi_cmake_modules']
 SHARED_MEMORY:
     parent_projects: ['COMPILATION', 'PYTHON_BINDING']
-    repos: ['shared_memory']
+    repos: ['shared_memory', 'serialization_utils']
 REAL_TIME_TOOLS:
     parent_projects: ['COMPILATION']
     repos: ['real_time_tools']

--- a/repositories_machines_in_motion.yaml
+++ b/repositories_machines_in_motion.yaml
@@ -65,6 +65,9 @@ synchronizer:
 signal_handler:
     path: src/catkin/tools
     origin: github_mpiis
+serialization_utils:
+    path: src/catkin/tools
+    origin: github_mpiis
 
 # -----------------------------------------------------------------------------
 # Doc


### PR DESCRIPTION
## Description
Add the serialization_utils package and add it to SHARED_MEMORY as it will soon be needed there.


## How I Tested

By cloning in a new workspace.

## I am not sure about
Is it good like this or should I follow the structure of the other packages and add a SERIALIZATION_UTILS project and depend on this?