### PR TITLE
Add trifinger simulation and models

### DIFF
--- a/repositories_machines_in_motion.yaml
+++ b/repositories_machines_in_motion.yaml
@@ -14,6 +14,9 @@ robot_properties_solo:
 robot_properties_bolt:
     path: src/catkin/robots/robot_properties/
     origin: github_odri
+robot_properties_fingers:
+    path: src/catkin/robots/robot_properties/
+    origin: github_odri
 
 # The robot low level control
 blmc_robots:
@@ -155,3 +158,6 @@ mw_gui_universal:
 pinocchio_bullet:
     path: src/catkin/robots/
     origin: github_mm
+trifinger_simulation:
+    path: src/catkin/simulators/
+    origin: github_odri


### PR DESCRIPTION
These repos have been moved to github, so they should also be in the
public treep config.