### PR TITLE
Remove master-board stuff from BLMC_DRIVERS

### DIFF
--- a/projects_machines_in_motion.yaml
+++ b/projects_machines_in_motion.yaml
@@ -60,18 +60,17 @@ BLMC_DEBUG_GUI:
     repos: ['mw_gui_universal']
 # robot drivers
 BLMC_DRIVERS:
+    parent_projects: ['CORE_ROBOTICS']
+    repos: ['blmc_drivers']
+# The old BLMC_DRIVERS.  This is deprecated, don't use it in new projects!
+BLMC_DRIVERS_LEGACY:
     parent_projects: ['COMPILATION', 'TIME_SERIES', 'CONFIGURATION_FILE_PARSING']
     repos: ['real_time_tools', 'master-board', 'blmc_drivers', 'odri_control_interface']
+
 
 ODRI_CONTROL_INTERFACE:
     parent_projects: ['COMPILATION', 'CONFIGURATION_FILE_PARSING']
     repos: ['real_time_tools', 'master-board', 'odri_control_interface']
-
-# like BLMC_DRIVERS but omits packages that are not needed for direct CAN
-# communication with the boards
-BLMC_DRIVERS_CAN_ONLY:
-    parent_projects: ['COMPILATION', 'TIME_SERIES', 'CONFIGURATION_FILE_PARSING']
-    repos: ['real_time_tools', 'master-board', 'blmc_drivers']
 
 # Additional drivers
 IMU_CORE_DEPENDENCIES:
@@ -125,7 +124,7 @@ ROBOT_PROPERTIES_ALL:
 # Robots
 
 SOLO_DEPENDENCIES:
-    parent_projects: ['BLMC_DRIVERS', 'ROBOT_PROPERTIES_SOLO', 'PYTHON_BINDING']
+    parent_projects: ['BLMC_DRIVERS_LEGACY', 'ROBOT_PROPERTIES_SOLO', 'PYTHON_BINDING']
 SOLO:
     parent_projects: ['SOLO_DEPENDENCIES']
     repos: ['solo']
@@ -134,13 +133,13 @@ DG_SOLO:
     repos: []
 
 BOLT_DEPENDENCIES:
-    parent_projects: ['BLMC_DRIVERS', 'ROBOT_PROPERTIES_BOLT', 'PYTHON_BINDING']
+    parent_projects: ['BLMC_DRIVERS_LEGACY', 'ROBOT_PROPERTIES_BOLT', 'PYTHON_BINDING']
 BOLT:
     parent_projects: [BOLT_DEPENDENCIES]
     repos: ['bolt']
 
 TESTSTAND_DEPENDENCIES:
-    parent_projects: ['BLMC_DRIVERS', 'ROBOT_PROPERTIES_TESTSTAND',
+    parent_projects: ['BLMC_DRIVERS_LEGACY', 'ROBOT_PROPERTIES_TESTSTAND',
                       'PYTHON_BINDING']
     repos: ['ati_ft_sensor']
 TESTSTAND:
@@ -161,7 +160,7 @@ DG_NYU_FINGER:
     repos: []
 
 ROBOT_FINGERS_DEPENDENCIES:
-    parent_projects: ['BLMC_DRIVERS_CAN_ONLY', 'ROBOT_INTERFACES']
+    parent_projects: ['BLMC_DRIVERS', 'ROBOT_INTERFACES']
     repos: [
       'pybind11_opencv',
       'trifinger_cameras',


### PR DESCRIPTION
## Description
With the recent update, blmc_drivers does not contain code related to
the master board anymore.  Therefore remove the corresponding packages
from the BLMC_DRIVERS project and remove the obsolete
BLMC_DRIVERS_CAN_ONLY project.

Add a BLMC_DRIVERS_LEGACY project with the old setup on which packages
can depend until they are updated to not depend on blmc_drivers anymore.
This project should be removed again, once all corresponding packages
have been updated.


## How I Tested

- Cloned and built the BLMC_DRIVERS project
- Cloned and built the ROBOT_FINGERS project
