### PR TITLE
Set googletest branch to "main"

### DIFF
--- a/repositories_machines_in_motion.yaml
+++ b/repositories_machines_in_motion.yaml
@@ -244,6 +244,7 @@ catkin:
 googletest:
     path: src/
     origin: google
+    branch: main
 
 # ------------------------------------------------------------------------------
 # Robot demos and research


### PR DESCRIPTION
This pull request sets the googletest branch to "main". 

See [https://github.com/google/googletest/issues/3671](https://github.com/google/googletest/issues/3671)
"origin/master disappeared, replaced with origin/main. Dependencies all over the world are broken"
