### PR TITLE
Bump version of pybind11 to 2.10.0

### DIFF
--- a/repositories_machines_in_motion.yaml
+++ b/repositories_machines_in_motion.yaml
@@ -16,7 +16,7 @@ yaml_utils:
 pybind11:
     path: src/
     origin: pybind
-    tag: v2.5.0
+    tag: v2.10.0
 pybind11_opencv:
     path: src/
     origin: odri


### PR DESCRIPTION
## Description

Bump version of pybind11 to 2.10.0.
One (for me) relevant change is that this allows binding `std::filesystem::path` to `pathlib.Path` which is not yet supported in 2.5.0.

## How I Tested

Compiled workspaces with the ROBOT_FINGERS and SOLO projects and ran the tests.