### PR TITLE
Bump pybind11 to v2.13.6 (latest 2.x)

### DIFF
--- a/repositories_machines_in_motion.yaml
+++ b/repositories_machines_in_motion.yaml
@@ -16,7 +16,7 @@ yaml_utils:
 pybind11:
     path: src/
     origin: pybind
-    tag: v2.10.0
+    tag: v2.13.6
 pybind11_opencv:
     path: src/
     origin: odri


### PR DESCRIPTION
## Description

Fixes an issue I had that PYTHONPATH was ignored when embedding Python in C++ in unit tests run via gtest (not sure if situations were affected as well, I only noticed it due to failing tests).

There is also a version 3.x by now but it has breaking changes, so I stick with the latest 2.x release for now.


## How I Tested

By printing and comparing `PYTHONPATH` and `sys.path` in the affected C++ code and also by the fact that the previously failing test of the robot_fingers package now pass.